### PR TITLE
don't decode html entities when parsing text

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 var tagTypes, blockTypes, sameAs,
   _ = require('lodash'),
   domify = require('domify'),
-  he = require('he'),
   nodeFilter = NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT;
 
 /**
@@ -274,7 +273,7 @@ function fromElement(el) {
 
     switch (type) {
       case Node.TEXT_NODE:
-        model.text += he.decode(node.nodeValue);
+        model.text += node.nodeValue;
         break;
       default:
         name = getNodeName(node);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/nymag/text-model#readme",
   "dependencies": {
     "domify": "^1.3",
-    "he": "^0.5",
     "lodash": "^4.6.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -33,6 +33,16 @@ describe('text-model', function () {
   describe('fromElement', function () {
     var fn = lib[this.title];
 
+    it('doesn\t decode sanitized html', function () {
+      var el = domify('Hello &lt;iframe&gt;'),
+        result = {
+          text: 'Hello &lt;iframe&gt;',
+          blocks: {}
+        };
+
+      expect(fn(el)).to.deep.equal(result);
+    });
+
     it('finds text', function () {
       var el = domify('Hello <strong>there <em>person</em></strong>!'),
         result = {
@@ -198,6 +208,16 @@ describe('text-model', function () {
 
   describe('toElement', function () {
     var fn = lib[this.title];
+
+    it('doesn\t decode sanitized html', function () {
+      var model = {
+          text: '&lt;Hello there person!&gt;',
+          blocks: {}
+        },
+        result = '<Hello there person>!';
+
+      expect(documentToString(fn(model))).to.not.equal(result);
+    });
 
     it('converts continuous blocks', function () {
       var model = {


### PR DESCRIPTION
when parsing text nodes, don't try to decode html entities. this is a security flaw that would allow html elements that were not allowed via `tagTypes`

![screen shot 2016-07-14 at 2 16 34 pm](https://cloud.githubusercontent.com/assets/447522/16850632/0e75528e-49ce-11e6-9dfd-f3bd7c3a03e5.png)
(attempting to paste html using "paste and match style")
