### PR TITLE
updateSameAs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,13 @@
 {
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 6
+  },
   "env": {
     "browser": true,
-    "node": true,
-    "mocha": true
+    "commonjs": true,
+    "mocha": true,
+    "es6": true,
   },
   // add global vars for chai, etc
   "globals": {
@@ -21,7 +26,8 @@
     "octalLiterals": true,
     "binaryLiterals": true,
     "templateStrings": true,
-    "generators": true
+    "generators": true,
+    "modules": true
   },
   "rules": {
     // possible errors
@@ -44,7 +50,7 @@
     "vars-on-top": 2,
     "wrap-iife": 2,
     // strict mode
-    "strict": [2, "global"],
+    "strict": [2, "never"],
     // variables
     "no-unused-vars": 2,
     // node.js

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Text Model
 
 Transform functionality to move between HTML Elements and a text model.
 
-[![Coverage Status](https://coveralls.io/repos/nymag/text-model/badge.svg?branch=master&service=github)](https://coveralls.io/github/nymag/text-model?branch=master)
+[![CircleCI](https://circleci.com/gh/nymag/text-model.svg?style=svg)](https://circleci.com/gh/nymag/text-model) [![Coverage Status](https://coveralls.io/repos/nymag/text-model/badge.svg?branch=master&service=github)](https://coveralls.io/github/nymag/text-model?branch=master)
 
 ```html
 Hello <a href="place" alt="hey">there</a> <u>person</u>!

--- a/README.md
+++ b/README.md
@@ -74,7 +74,21 @@ textModel.setSameAs({
 });
 ```
 
-These tags will be converted if they are seen.  The defaults are as above.
+These tags will be converted if they are seen. The defaults are as above, but you can pass in an object of tag names (uppercase) that will merge and overwrite them. To _remove_ a default conversion, simply pass `<tagname>: null` in the object:
+
+```js
+textModel.setSameAs({
+  'B': null, // override default, don't convert <b> to <strong>
+  'H1': 'STRONG', // convert ALL headers to <strong>
+  'H2': 'STRONG',
+  'H3': 'STRONG',
+  'H4': 'STRONG',
+  'H5': 'STRONG',
+  'H6': 'STRONG',
+  'SPAN': 'EM', // convert all spans to <em>
+  'STRIKE': null // don't convert <strike>. this will remove the tag as <strike> is deprecated in html (and thus removed by text-model)
+});
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ paragraphEl.appendChild(textModel.toElement(splitModels[1]));
 ## Optional Configuration
 
 ```js
-textModel.setSameAs({
+textModel.updateSameAs({
   'B': 'STRONG',
   'U': 'EM',
   'I': 'EM',
@@ -77,7 +77,7 @@ textModel.setSameAs({
 These tags will be converted if they are seen. The defaults are as above, but you can pass in an object of tag names (uppercase) that will merge and overwrite them. To _remove_ a default conversion, simply pass `<tagname>: null` in the object:
 
 ```js
-textModel.setSameAs({
+textModel.updateSameAs({
   'B': null, // override default, don't convert <b> to <strong>
   'H1': 'STRONG', // convert ALL headers to <strong>
   'H2': 'STRONG',

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   timezone:
     America/New_York
   node:
-    version: iojs-v2.3.1
+    version: 4.5.0
 dependencies:
   pre:
     - npm install -g karma-cli

--- a/index.js
+++ b/index.js
@@ -217,19 +217,11 @@ blockTypes = _.transform(tagTypes, function (obj, tag, name) {
  *
  * Expect this list to change often, so don't write code that relies on specific values.
  *
+ * These are set in clearSameAs()
+ *
  * @enum
  */
-sameAs = {
-  B: 'STRONG',
-  U: 'EM',
-  I: 'EM',
-  H1: 'H2',
-  H3: 'H2',
-  H4: 'H2',
-  H5: 'H2',
-  H6: 'H2',
-  STRIKE: 'DEL'
-};
+sameAs = {};
 
 /**
  * @param {Node} el
@@ -803,8 +795,26 @@ module.exports.concat = concat;
 /**
  * merge custom conversion table
  * note: to remove a default conversion, simply pass <TAGNAME>: null
- * @param {object} obj tagname mappings
+ * note: calling this with no obj sets the default conversions
+ * @param {object} [obj] tagname mappings
  */
 module.exports.setSameAs = function (obj) {
-  sameAs = _.assign(sameAs, obj);
+  if (obj) {
+    sameAs = _.assign(sameAs, obj);
+  } else {
+    sameAs = {
+      B: 'STRONG',
+      U: 'EM',
+      I: 'EM',
+      H1: 'H2',
+      H3: 'H2',
+      H4: 'H2',
+      H5: 'H2',
+      H6: 'H2',
+      STRIKE: 'DEL'
+    };
+  }
 };
+
+// when this library is first loaded, set the default conversions
+module.exports.setSameAs();

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function contentTextOnly(node) {
 function knownTagsOnly(node) {
   var name = node.nodeName;
 
-  return !!tagTypes[name] || node.nodeType === Node.TEXT_NODE && contentTextOnly(node);
+  return !!tagTypes[name] || !!sameAs[name] || node.nodeType === Node.TEXT_NODE && contentTextOnly(node);
 }
 
 /**
@@ -799,3 +799,11 @@ module.exports.fromElement = fromElement;
 module.exports.toElement = toElement;
 module.exports.split = split;
 module.exports.concat = concat;
+
+/**
+ * merge custom conversion table
+ * @param {object} obj tagname mappings
+ */
+module.exports.setSameAs = function (obj) {
+  sameAs = _.assign(sameAs, obj);
+};

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ blockTypes = _.transform(tagTypes, function (obj, tag, name) {
  *
  * Expect this list to change often, so don't write code that relies on specific values.
  *
- * These are set in clearSameAs()
+ * These are set in setSameAs()
  *
  * @enum
  */

--- a/index.js
+++ b/index.js
@@ -802,6 +802,7 @@ module.exports.concat = concat;
 
 /**
  * merge custom conversion table
+ * note: to remove a default conversion, simply pass <TAGNAME>: null
  * @param {object} obj tagname mappings
  */
 module.exports.setSameAs = function (obj) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var tagTypes, blockTypes, sameAs,
+var tagTypes, blockTypes, defaultSameAs, sameAs,
   _ = require('lodash'),
   domify = require('domify'),
   nodeFilter = NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT;
@@ -217,11 +217,21 @@ blockTypes = _.transform(tagTypes, function (obj, tag, name) {
  *
  * Expect this list to change often, so don't write code that relies on specific values.
  *
- * These are set in setSameAs()
- *
  * @enum
  */
-sameAs = {};
+defaultSameAs = {
+  B: 'STRONG',
+  U: 'EM',
+  I: 'EM',
+  H1: 'H2',
+  H3: 'H2',
+  H4: 'H2',
+  H5: 'H2',
+  H6: 'H2',
+  STRIKE: 'DEL'
+};
+
+sameAs = _.clone(defaultSameAs); // this will be changed by setSameAs
 
 /**
  * @param {Node} el
@@ -795,26 +805,13 @@ module.exports.concat = concat;
 /**
  * merge custom conversion table
  * note: to remove a default conversion, simply pass <TAGNAME>: null
- * note: calling this with no obj sets the default conversions
- * @param {object} [obj] tagname mappings
+ * @param {object} obj tagname mappings
  */
 module.exports.setSameAs = function (obj) {
-  if (obj) {
-    sameAs = _.assign(sameAs, obj);
-  } else {
-    sameAs = {
-      B: 'STRONG',
-      U: 'EM',
-      I: 'EM',
-      H1: 'H2',
-      H3: 'H2',
-      H4: 'H2',
-      H5: 'H2',
-      H6: 'H2',
-      STRIKE: 'DEL'
-    };
-  }
+  sameAs = _.assign(sameAs, obj);
 };
 
-// when this library is first loaded, set the default conversions
-module.exports.setSameAs();
+// reset the defaults, used for testing setSameAs
+module.exports.resetSameAs = function () {
+  sameAs = _.clone(defaultSameAs);
+};

--- a/index.js
+++ b/index.js
@@ -807,7 +807,7 @@ module.exports.concat = concat;
  * note: to remove a default conversion, simply pass <TAGNAME>: null
  * @param {object} obj tagname mappings
  */
-module.exports.setSameAs = function (obj) {
+module.exports.updateSameAs = function (obj) {
   sameAs = _.assign(sameAs, obj);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-'use strict';
 var tagTypes, blockTypes, defaultSameAs, sameAs,
   _ = require('lodash'),
   domify = require('domify'),

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-'use strict';
 var _ = require('lodash'),
   lib = require('./index'),
   domify = require('domify');

--- a/test.js
+++ b/test.js
@@ -571,6 +571,6 @@ describe('text-model', function () {
       });
 
       expect(lib.fromElement(el)).to.deep.equal(result);
-    })
+    });
   });
 });

--- a/test.js
+++ b/test.js
@@ -597,4 +597,31 @@ describe('text-model', function () {
       expect(lib.fromElement(el)).to.deep.equal(result);
     });
   });
+
+  describe('resetSameAs', function () {
+    var fn = lib[this.title];
+
+    it('resets the default conversions', function () {
+      var el = domify('<b>a</b><u>b</u><i>c</i><h1>d</h1><h3>e</h3><h4>f</h4><h5>g</h5><h6>h</h6><strike>i</strike>'),
+        result = {
+          text: 'abcdefghi',
+          blocks: {
+            strong: [0, 1],
+            emphasis: [1, 3],
+            h2: [3, 8],
+            del: [8, 9]
+          }
+        };
+
+      // set conversions to some weird state
+      lib.updateSameAs({
+        B: null,
+        U: null,
+        I: null
+      });
+      fn(); // reset them
+
+      expect(lib.fromElement(el)).to.deep.equal(result); // default conversions
+    });
+  });
 });

--- a/test.js
+++ b/test.js
@@ -531,4 +531,46 @@ describe('text-model', function () {
       expect(documentToString(lib.toElement(result))).to.deep.equal(expectedResult);
     });
   });
+
+  describe('setSameAs', function () {
+    var fn = lib[this.title];
+
+    it('uses default mappings for tag conversions', function () {
+      var el = domify('<b>a</b><u>b</u><i>c</i><h1>d</h1><h3>e</h3><h4>f</h4><h5>g</h5><h6>h</h6><strike>i</strike>'),
+        result = {
+          text: 'abcdefghi',
+          blocks: {
+            strong: [0, 1],
+            emphasis: [1, 3],
+            h2: [3, 8],
+            del: [8, 9]
+          }
+        };
+
+      expect(lib.fromElement(el)).to.deep.equal(result);
+    });
+
+    it('merges in user conversions', function () {
+      var el = domify('<b>a</b><u>b</u><i>c</i><h1>d</h1><h2>e</h2><h3>f</h3><h4>g</h4><h5>h</h5><h6>i</h6><strike>j</strike>'),
+        result = {
+          text: 'abcdefghij',
+          blocks: {
+            strong: [0, 1, 3, 9],
+            emphasis: [1, 3],
+            del: [9, 10]
+          }
+        };
+
+      fn({
+        H1: 'STRONG',
+        H2: 'STRONG',
+        H3: 'STRONG',
+        H4: 'STRONG',
+        H5: 'STRONG',
+        H6: 'STRONG',
+      });
+
+      expect(lib.fromElement(el)).to.deep.equal(result);
+    })
+  });
 });

--- a/test.js
+++ b/test.js
@@ -561,6 +561,7 @@ describe('text-model', function () {
           }
         };
 
+      fn(); // set defaults
       fn({
         H1: 'STRONG',
         H2: 'STRONG',
@@ -568,6 +569,29 @@ describe('text-model', function () {
         H4: 'STRONG',
         H5: 'STRONG',
         H6: 'STRONG',
+      });
+
+      expect(lib.fromElement(el)).to.deep.equal(result);
+    });
+
+    it('allows removing default conversions', function () {
+      var el = domify('<b>a</b><u>b</u><i>c</i><h1>d</h1><h3>e</h3><h4>f</h4><h5>g</h5><h6>h</h6><strike>i</strike>'),
+        result = {
+          text: 'abcdefghi',
+          blocks: {
+            bold: [0, 1],
+            underline: [1, 2],
+            italic: [2, 3],
+            h2: [3, 8],
+            del: [8, 9]
+          }
+        };
+
+      fn(); // set defaults
+      fn({
+        B: null,
+        U: null,
+        I: null
       });
 
       expect(lib.fromElement(el)).to.deep.equal(result);

--- a/test.js
+++ b/test.js
@@ -561,7 +561,7 @@ describe('text-model', function () {
           }
         };
 
-      fn(); // set defaults
+      lib.resetSameAs();
       fn({
         H1: 'STRONG',
         H2: 'STRONG',
@@ -587,7 +587,7 @@ describe('text-model', function () {
           }
         };
 
-      fn(); // set defaults
+      lib.resetSameAs();
       fn({
         B: null,
         U: null,

--- a/test.js
+++ b/test.js
@@ -532,7 +532,7 @@ describe('text-model', function () {
     });
   });
 
-  describe('setSameAs', function () {
+  describe('updateSameAs', function () {
     var fn = lib[this.title];
 
     it('uses default mappings for tag conversions', function () {


### PR DESCRIPTION
- added the exported method that was referenced in the readme
- it _merges_ the object passed into it, not straight overwriting
- this allows a lot of flexibility
- pass `<tagname>: null` to _remove_ default conversions
