### PR TITLE
Add sup and sub tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,8 @@ tagTypes = {
   EM: { set: continuous, name: 'emphasis' },
   STRONG: { set: continuous, name: 'strong' },
   PRE: { set: continuous, name: 'pre'},
+  SUP: { set: continuous, name: 'sup'},
+  SUB: { set: continuous, name: 'sub'},
   DEL: { set: continuous, name: 'del' },
   H1: { set: continuous, name: 'h1' },
   H2: { set: continuous, name: 'h2' },


### PR DESCRIPTION
In our very first article, we found that we needed the [SUP tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup) to be pastable. I know the tag is only in the HTML5 Recommendation, but it was in what we pasted and seems harmless, so not sure why not.

To Test, go to our [wonderweek cover story](https://redux.slate.com/cover_story/2016/12/the-greatest-creative-run-in-the-history-of-pop-music.html) and copy/paste the first paragraph (which has 21st) in it into a paragraph component in a clay site.

Prior to this commit the "st" on 21st just disappears. With this it should now show up.

Perhaps a better approach to this would be to allow the tagTypes to be overridable similar to sameAs with an updateTagTypes method? Happy to implement that if you think it's better.

I tested this by updating my local clay-kiln text-model dependency to be:

`"text-model": "file:../text-model/",`

and updating my sites clay-kiln dependency to be:

`"clay-kiln": "file:../clay-kiln/",`

In a folder tree where text-model, clay-kiln, and my site are all siblings.

Then I had to make sure to run `npm install` in both clay-kiln _and_ my site to pick it up.

